### PR TITLE
Standardize all imports to prefer the "from PACKAGE import MODULE" syntax

### DIFF
--- a/scripts/spitfire-compile
+++ b/scripts/spitfire-compile
@@ -7,30 +7,31 @@
 
 
 import logging
+import optparse
 import os
 import os.path
 import sys
 
 import spitfire
-from spitfire.compiler import compiler as sptcompiler
-from spitfire.compiler import options as sptoptions
+from spitfire.compiler import compiler
+from spitfire.compiler import options
 
 
-def process_file(compiler, filename, options):
+def process_file(spt_compiler, filename, options):
   def print_output(*args):
     if options.verbose:
       print >> sys.stderr, ' '.join(args)
 
   try:
     if options.output_file:
-      compiler.write_file = False
+      spt_compiler.write_file = False
       if options.output_file == '-':
         f = sys.stdout
       else:
         f = open(options.output_file, 'w')
     else:
-      compiler.write_file = True
-    src_code = compiler.compile_file(filename)
+      spt_compiler.write_file = True
+    src_code = spt_compiler.compile_file(filename)
     if options.output_file:
       f.write(src_code)
       f.close()
@@ -48,17 +49,16 @@ if __name__ == '__main__':
   reload(sys)
   sys.setdefaultencoding('utf8')
 
-  from optparse import OptionParser
-  op = OptionParser()
-  sptoptions.add_common_options(op)
-  (options, args) = op.parse_args()
+  option_parser = optparse.OptionParser()
+  options.add_common_options(option_parser)
+  (spt_options, spt_args) = option_parser.parse_args()
 
-  if options.version:
+  if spt_options.version:
     print >> sys.stderr, 'spitfire %s' % spitfire.__version__
     sys.exit(0)
 
-  compiler_args = sptcompiler.Compiler.args_from_optparse(options)
-  compiler = sptcompiler.Compiler(**compiler_args)
+  spt_compiler_args = compiler.Compiler.args_from_optparse(spt_options)
+  spt_compiler = compiler.Compiler(**spt_compiler_args)
 
-  for filename in args:
-    process_file(compiler, filename, options)
+  for filename in spt_args:
+    process_file(spt_compiler, filename, spt_options)

--- a/spitfire/compiler/analyzer_test.py
+++ b/spitfire/compiler/analyzer_test.py
@@ -5,26 +5,26 @@
 
 import unittest
 
-from spitfire import test_util
-from spitfire.compiler.ast import *
 from spitfire.compiler import analyzer
-from spitfire.compiler import options as sptoptions
-from spitfire.compiler import compiler as sptcompiler
+from spitfire.compiler import ast
+from spitfire.compiler import compiler
+from spitfire.compiler import options
 from spitfire.compiler import util
 from spitfire.compiler import walker
+from spitfire import test_util
 
 
 class BaseTest(unittest.TestCase):
 
   def __init__(self, *args):
     unittest.TestCase.__init__(self, *args)
-    self.options = sptoptions.default_options
-    self.options.update(cache_resolved_placeholders=True,
+    self.analyzer_options = options.default_options
+    self.analyzer_options.update(cache_resolved_placeholders=True,
                         enable_warnings=True, warnings_as_errors=True)
 
   def setUp(self):
-    self.compiler = sptcompiler.Compiler(
-        analyzer_options=self.options,
+    self.compiler = compiler.Compiler(
+        analyzer_options=self.analyzer_options,
         xspt_mode=False,
         compiler_stack_traces=True)
 
@@ -45,8 +45,8 @@ class BaseTest(unittest.TestCase):
     #def test_function
     #end def
     """
-    ast_root = TemplateNode('TestTemplate')
-    def_node = DefNode('test_function')
+    ast_root = ast.TemplateNode('TestTemplate')
+    def_node = ast.DefNode('test_function')
     ast_root.append(def_node)
     return (ast_root, def_node)
 
@@ -60,8 +60,8 @@ class BaseTest(unittest.TestCase):
     #end def
     """
     ast_root, def_node = self._build_function_template()
-    condition_node = condition or LiteralNode(True)
-    if_node = IfNode(condition_node)
+    condition_node = condition or ast.LiteralNode(True)
+    if_node = ast.IfNode(condition_node)
     def_node.append(if_node)
     return (ast_root, def_node, if_node)
 
@@ -98,7 +98,7 @@ class TestEmptyIfBlockError(BaseTest):
     #end def
     """
     ast_root, def_node, if_node = self._build_if_template()
-    if_node.append(OptionalWhitespaceNode(' '))
+    if_node.append(ast.OptionalWhitespaceNode(' '))
 
     semantic_analyzer = self._get_analyzer(ast_root)
 
@@ -115,7 +115,7 @@ class TestEmptyIfBlockError(BaseTest):
     #end def
     """
     ast_root, def_node, if_node = self._build_if_template()
-    if_node.append(CommentNode(' This is a comment.'))
+    if_node.append(ast.CommentNode(' This is a comment.'))
 
     semantic_analyzer = self._get_analyzer(ast_root)
 
@@ -133,7 +133,7 @@ class TestEmptyIfBlockError(BaseTest):
     #end def
     """
     ast_root, def_node, if_node = self._build_if_template()
-    assign_node = AssignNode(IdentifierNode('foo'), LiteralNode(True))
+    assign_node = ast.AssignNode(ast.IdentifierNode('foo'), ast.LiteralNode(True))
     if_node.else_.append(assign_node)
 
     semantic_analyzer = self._get_analyzer(ast_root)
@@ -152,9 +152,9 @@ class TestEmptyIfBlockError(BaseTest):
     #end def
     """
     ast_root, def_node, if_node = self._build_if_template()
-    assign_node = AssignNode(IdentifierNode('foo'), LiteralNode(True))
+    assign_node = ast.AssignNode(ast.IdentifierNode('foo'), ast.LiteralNode(True))
     if_node.append(assign_node)
-    elif_node = IfNode(LiteralNode(False))
+    elif_node = ast.IfNode(ast.LiteralNode(False))
     if_node.else_.append(elif_node)
     semantic_analyzer = self._get_analyzer(ast_root)
 
@@ -171,7 +171,7 @@ class TestEmptyIfBlockError(BaseTest):
     #end def
     """
     ast_root, def_node, if_node = self._build_if_template()
-    assign_node = AssignNode(IdentifierNode('foo'), LiteralNode(True))
+    assign_node = ast.AssignNode(ast.IdentifierNode('foo'), ast.LiteralNode(True))
     if_node.append(assign_node)
 
     semantic_analyzer = self._get_analyzer(ast_root)
@@ -194,11 +194,11 @@ class TestEmptyForBlockError(BaseTest):
     #end def
     """
     ast_root, def_node = self._build_function_template()
-    target_list = TargetListNode()
-    target_list.append(PlaceholderNode('foo'))
-    expression_list = ExpressionListNode()
-    expression_list.append(LiteralNode([]))
-    for_node = ForNode(target_list=target_list, expression_list=expression_list)
+    target_list = ast.TargetListNode()
+    target_list.append(ast.PlaceholderNode('foo'))
+    expression_list = ast.ExpressionListNode()
+    expression_list.append(ast.LiteralNode([]))
+    for_node = ast.ForNode(target_list=target_list, expression_list=expression_list)
     def_node.append(for_node)
     return (ast_root, def_node, for_node)
 
@@ -227,7 +227,7 @@ class TestEmptyForBlockError(BaseTest):
     #end def
     """
     ast_root, def_node, for_node = self._build_for_template()
-    for_node.append(OptionalWhitespaceNode(' '))
+    for_node.append(ast.OptionalWhitespaceNode(' '))
 
     semantic_analyzer = self._get_analyzer(ast_root)
 
@@ -244,7 +244,7 @@ class TestEmptyForBlockError(BaseTest):
     #end def
     """
     ast_root, def_node, for_node = self._build_for_template()
-    for_node.append(CommentNode(' This is a comment.'))
+    for_node.append(ast.CommentNode(' This is a comment.'))
 
     semantic_analyzer = self._get_analyzer(ast_root)
 
@@ -261,7 +261,7 @@ class TestEmptyForBlockError(BaseTest):
     #end def
     """
     ast_root, def_node, for_node = self._build_for_template()
-    assign_node = AssignNode(IdentifierNode('foo'), LiteralNode(True))
+    assign_node = ast.AssignNode(ast.IdentifierNode('foo'), ast.LiteralNode(True))
     for_node.append(assign_node)
 
     semantic_analyzer = self._get_analyzer(ast_root)
@@ -282,10 +282,10 @@ class TestGlobalScopeLibraryError(BaseTest):
     #def test_function
     #end def
     """
-    ast_root = TemplateNode('TestTemplate')
-    implements_node = ImplementsNode('library')
+    ast_root = ast.TemplateNode('TestTemplate')
+    implements_node = ast.ImplementsNode('library')
     ast_root.append(implements_node)
-    def_node = DefNode('test_function')
+    def_node = ast.DefNode('test_function')
     ast_root.append(def_node)
     return (ast_root, def_node)
 
@@ -314,7 +314,7 @@ class TestGlobalScopeLibraryError(BaseTest):
     #end def
     """
     ast_root, def_node = self._build_function_template_library()
-    assign_node = AssignNode(IdentifierNode('foo'), LiteralNode(True))
+    assign_node = ast.AssignNode(ast.IdentifierNode('foo'), ast.LiteralNode(True))
     ast_root.insert_before(def_node, assign_node)
 
     semantic_analyzer = self._get_analyzer(ast_root)
@@ -331,7 +331,7 @@ class TestGlobalScopeLibraryError(BaseTest):
     #end def
     """
     ast_root, def_node = self._build_function_template_library()
-    attr_node = AttributeNode('foo', default=LiteralNode(True))
+    attr_node = ast.AttributeNode('foo', default=ast.LiteralNode(True))
     ast_root.insert_before(def_node, attr_node)
 
     semantic_analyzer = self._get_analyzer(ast_root)
@@ -348,7 +348,7 @@ class TestGlobalScopeLibraryError(BaseTest):
     #end def
     """
     ast_root, def_node = self._build_function_template_library()
-    global_node = GlobalNode('foo')
+    global_node = ast.GlobalNode('foo')
     ast_root.insert_before(def_node, global_node)
 
     semantic_analyzer = self._get_analyzer(ast_root)
@@ -369,8 +369,8 @@ class TestAssignSlice(BaseTest):
     #end def
     """
     ast_root, def_node = self._build_function_template()
-    assign_node = AssignNode(SliceNode(LiteralNode(1), LiteralNode(1)),
-                             LiteralNode(1))
+    assign_node = ast.AssignNode(ast.SliceNode(ast.LiteralNode(1), ast.LiteralNode(1)),
+                             ast.LiteralNode(1))
     def_node.append(assign_node)
 
     semantic_analyzer = self._get_analyzer(ast_root)
@@ -386,8 +386,8 @@ class TestAssignSlice(BaseTest):
     #end def
     """
     ast_root, def_node = self._build_function_template()
-    assign_node = AssignNode(SliceNode(IdentifierNode('foo'), LiteralNode(1)),
-                             LiteralNode(1))
+    assign_node = ast.AssignNode(ast.SliceNode(ast.IdentifierNode('foo'), ast.LiteralNode(1)),
+                             ast.LiteralNode(1))
     def_node.append(assign_node)
 
     semantic_analyzer = self._get_analyzer(ast_root)
@@ -401,12 +401,12 @@ class TestAssignSlice(BaseTest):
 class TestSanitizedFunction(BaseTest):
 
   def setUp(self):
-    self.options = sptoptions.default_options
-    self.options.update(cache_resolved_placeholders=True,
+    self.analyzer_options = options.default_options
+    self.analyzer_options.update(cache_resolved_placeholders=True,
                         enable_warnings=True, warnings_as_errors=True,
                         baked_mode=True, generate_unicode=False)
-    self.compiler = sptcompiler.Compiler(
-        analyzer_options=self.options,
+    self.compiler = compiler.Compiler(
+        analyzer_options=self.analyzer_options,
         xspt_mode=False,
         compiler_stack_traces=True)
     self.compiler.new_registry_format = True
@@ -426,15 +426,15 @@ class TestSanitizedFunction(BaseTest):
     semantic_analyzer = self._get_analyzer(template)
     analyzed_ast = semantic_analyzer.get_ast()
     def pred(node):
-      return (type(node) == CallFunctionNode and
-              type(node.expression) == PlaceholderNode and
+      return (type(node) == ast.CallFunctionNode and
+              type(node.expression) == ast.PlaceholderNode and
               node.expression.name == 'foo')
 
     foo_call = walker.find_node(analyzed_ast, pred)
     if not foo_call:
       self.fail('Expected foo() in ast')
     self.assertEqual(foo_call.sanitization_state,
-                     SanitizedState.SANITIZED_STRING)
+                     ast.SanitizedState.SANITIZED_STRING)
 
   def test_library_function_direct(self):
     code = """
@@ -448,15 +448,15 @@ class TestSanitizedFunction(BaseTest):
     semantic_analyzer = self._get_analyzer(template)
     analyzed_ast = semantic_analyzer.get_ast()
     def pred(node):
-      return (type(node) == CallFunctionNode and
-              type(node.expression) == IdentifierNode and
+      return (type(node) == ast.CallFunctionNode and
+              type(node.expression) == ast.IdentifierNode and
               node.expression.name == 'my_lib.foo')
 
     foo_call = walker.find_node(analyzed_ast, pred)
     if not foo_call:
       self.fail('Expected my_lib.foo() in ast')
     self.assertEqual(foo_call.sanitization_state,
-                     SanitizedState.SANITIZED_STRING)
+                     ast.SanitizedState.SANITIZED_STRING)
 
   def test_library_function_registry_yes(self):
     code = """
@@ -468,15 +468,15 @@ class TestSanitizedFunction(BaseTest):
     semantic_analyzer = self._get_analyzer(template)
     analyzed_ast = semantic_analyzer.get_ast()
     def pred(node):
-      return (type(node) == CallFunctionNode and
-              type(node.expression) == PlaceholderNode and
+      return (type(node) == ast.CallFunctionNode and
+              type(node.expression) == ast.PlaceholderNode and
               node.expression.name == 'reg_f')
 
     foo_call = walker.find_node(analyzed_ast, pred)
     if not foo_call:
       self.fail('Expected reg_f() in ast')
     self.assertEqual(foo_call.sanitization_state,
-                     SanitizedState.SANITIZED)
+                     ast.SanitizedState.SANITIZED)
 
   def test_external_function_maybe(self):
     code = """
@@ -490,9 +490,9 @@ class TestSanitizedFunction(BaseTest):
     semantic_analyzer = self._get_analyzer(template)
     analyzed_ast = semantic_analyzer.get_ast()
     def pred(node):
-      return (type(node) == CallFunctionNode and
-              type(node.expression) == GetUDNNode and
-              type(node.expression.expression) == PlaceholderNode and
+      return (type(node) == ast.CallFunctionNode and
+              type(node.expression) == ast.GetUDNNode and
+              type(node.expression.expression) == ast.PlaceholderNode and
               node.expression.expression.name == 'my_lib' and
               node.expression.name == 'foo')
 
@@ -500,17 +500,17 @@ class TestSanitizedFunction(BaseTest):
     if not foo_call:
       self.fail('Expected my_libfoo() in ast')
     self.assertEqual(foo_call.sanitization_state,
-                     SanitizedState.UNKNOWN)
+                     ast.SanitizedState.UNKNOWN)
 
 
 class TestNoRaw(BaseTest):
 
   def setUp(self):
-    self.options = sptoptions.default_options
-    self.options.update(enable_warnings=True, warnings_as_errors=True,
+    self.analyzer_options = options.default_options
+    self.analyzer_options.update(enable_warnings=True, warnings_as_errors=True,
                         no_raw=True)
-    self.compiler = sptcompiler.Compiler(
-        analyzer_options=self.options,
+    self.compiler = compiler.Compiler(
+        analyzer_options=self.analyzer_options,
         xspt_mode=False,
         compiler_stack_traces=True)
 

--- a/spitfire/compiler/macros/i18n.py
+++ b/spitfire/compiler/macros/i18n.py
@@ -8,8 +8,9 @@ import sys
 import cStringIO as StringIO
 
 from spitfire.compiler import analyzer
-from spitfire.compiler.ast import *
-from spitfire.compiler.visitor import print_tree
+from spitfire.compiler import ast
+from spitfire.compiler import util
+from spitfire.compiler import visitor
 from spitfire import text
 from spitfire.compiler import util
 
@@ -18,11 +19,11 @@ from spitfire.compiler import util
 def make_placeholder_name(placeholder_node):
   node_type = type(placeholder_node.expression)
   placeholder_name = ''
-  if node_type is PlaceholderNode:
+  if node_type is ast.PlaceholderNode:
     placeholder_name = placeholder_node.expression.name
-  elif node_type is CallFunctionNode:
+  elif node_type is ast.CallFunctionNode:
     placeholder = placeholder_node.expression.expression
-    if type(placeholder) is PlaceholderNode:
+    if type(placeholder) is ast.PlaceholderNode:
       placeholder_name = placeholder.name
 
   placeholder_name = placeholder_name.upper()
@@ -39,7 +40,7 @@ def make_i18n_message(raw_msg, macro_ast):
     #print i, type(n), "start", n.start, "end", n.end
     #print "raw:", "'%s'" % raw_msg[n.start:n.end]
 
-    if isinstance(n, PlaceholderSubstitutionNode):
+    if isinstance(n, ast.PlaceholderSubstitutionNode):
       raw_placeholder_expression = raw_msg[n.start:n.end]
       #output.write(make_placeholder_name(n))
       output.write(raw_placeholder_expression)
@@ -54,14 +55,13 @@ def macro_i18n(macro_node, arg_map, compiler):
 
   # generate a fake translation for now to verify this is working
   # most apps will have to stub this part out somehow i think
-  macro_content_ast = util.parse(macro_node.value,
-                                                   'i18n_goal')
+  macro_content_ast = util.parse(macro_node.value, 'i18n_goal')
   i18n_msg = make_i18n_message(macro_node.value, macro_content_ast)
   i18n_msg_utf8 = i18n_msg.encode(sys.getdefaultencoding())
   #print "macro_content_ast"
   #print "orginal:", macro_node.value
   #print "i18n:", i18n_msg_utf8
-  #print_tree(macro_content_ast)
+  #visitor.print_tree(macro_content_ast)
   return i18n_msg
 
 def macro_function_i18n(call_node, arg_map, compiler):
@@ -71,7 +71,7 @@ def macro_function_i18n(call_node, arg_map, compiler):
   # translated literal string. we have to do some shenanigans since Spitfire
   # doesn't parse repr(unicode)
   msg_arg_node = call_node.arg_list.parg_list[0]
-  if not isinstance(msg_arg_node, LiteralNode):
+  if not isinstance(msg_arg_node, ast.LiteralNode):
     raise analyzer.SemanticAnalyzerError(
       '$i18n argument "%s" must be a string literal' % msg_arg_node)
   i18n_msg = text.i18n_mangled_message(msg_arg_node.value)

--- a/spitfire/compiler/optimizer.py
+++ b/spitfire/compiler/optimizer.py
@@ -3,17 +3,16 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+import __builtin__
 import copy
 import logging
 import os.path
 import re
 
-from spitfire.compiler.ast import *
-from spitfire.compiler.analyzer import *
-from spitfire.compiler.visitor import print_tree
-from spitfire.compiler.walker import flatten_tree
+from spitfire.compiler import ast
+from spitfire.compiler import analyzer
+from spitfire.compiler import walker
 
-import __builtin__
 builtin_names = vars(__builtin__)
 
 _BINOP_INVALID_COUNT = 1000  # Any value > 0 will work.
@@ -36,11 +35,11 @@ def _get_parent_node_by_type(node, node_type):
   return _get_parent_node_by_pred(node, lambda n: isinstance(n, node_type))
 
 def _get_parent_loop(node):
-  return _get_parent_node_by_type(node, ForNode)
+  return _get_parent_node_by_type(node, ast.ForNode)
 
 def _get_parent_block(node):
   return _get_parent_node_by_type(node,
-                                  (FunctionNode, ForNode, IfNode, ElseNode))
+                                  (ast.FunctionNode, ast.ForNode, ast.IfNode, ast.ElseNode))
 
 def _get_local_identifiers(node):
   local_identifiers = []
@@ -51,24 +50,24 @@ def _get_local_identifiers(node):
   # fixme: should this be recursive?
   node = node.parent
   while node is not None:
-    if isinstance(node, ForNode):
+    if isinstance(node, ast.ForNode):
       local_identifiers.extend(node.loop_variant_set)
       local_identifiers.extend(node.scope.local_identifiers)
       partial_local_identifiers.extend(node.scope.partial_local_identifiers)
       dirty_local_identifiers.extend(node.scope.dirty_local_identifiers)
-    elif isinstance(node, IfNode):
+    elif isinstance(node, ast.IfNode):
       local_identifiers.extend(node.scope.local_identifiers)
       partial_local_identifiers.extend(node.scope.partial_local_identifiers)
       dirty_local_identifiers.extend(node.scope.dirty_local_identifiers)
-    elif isinstance(node, ElseNode):
+    elif isinstance(node, ast.ElseNode):
       # in this case, we don't want to go to the parent node, which is the
-      # IfNode - we want to go to the parent 'scope'
+      # ast.IfNode - we want to go to the parent scope
       local_identifiers.extend(node.scope.local_identifiers)
       partial_local_identifiers.extend(node.scope.partial_local_identifiers)
       dirty_local_identifiers.extend(node.scope.dirty_local_identifiers)
       node = node.parent.parent
       continue
-    elif isinstance(node, FunctionNode):
+    elif isinstance(node, ast.FunctionNode):
       local_identifiers.extend(node.scope.local_identifiers)
       partial_local_identifiers.extend(node.scope.partial_local_identifiers)
       dirty_local_identifiers.extend(node.scope.dirty_local_identifiers)
@@ -81,9 +80,9 @@ def _get_identifiers_from_expression(node):
 
   This function searches through the nodes of an expression and returns a set
   of the IdentiferNodes that are present. This function doesn't traverse
-  GetAttrNode or any LiteralNodes such as ListLiteral or DictLiteral nodes.
+  ast.GetAttrNode or any LiteralNodes such as ListLiteral or DictLiteral nodes.
   """
-  return set([n for n in flatten_tree(node) if isinstance(n, IdentifierNode)])
+  return set([n for n in walker.flatten_tree(node) if isinstance(n, ast.IdentifierNode)])
 
 def _is_clean(node, scope):
   """Determine if the node references any dirty identifiers in the scope.
@@ -116,11 +115,11 @@ def _get_common_aliased_expression_map(*scopes):
 # Utility functions for generating names.
 def _generate_filtered_placeholder(node):
   """Given a node, generate a name for the cached filtered placeholder"""
-  return '_fph%08X' % unsigned_hash(node)
+  return '_fph%08X' % ast.unsigned_hash(node)
 
 def _generate_cached_resolved_placeholder(node):
   """Given a node, generate a name for the cached udn placeholder"""
-  return '_rudn%08X' % unsigned_hash(node)
+  return '_rudn%08X' % ast.unsigned_hash(node)
 
 class _BaseAnalyzer(object):
   def __init__(self, ast_root, options, compiler):
@@ -160,28 +159,28 @@ class _BaseAnalyzer(object):
 
   # this function has some rules that are a bit unclean - you aren't actually
   # looking for the 'parent' scope, but one you might insert nodes into.
-  # for instance, you skip over a ForNode so that optimizetions are inserted
+  # for instance, you skip over a ast.ForNode so that optimizetions are inserted
   # in a loop-invariant fashion.
   def get_parent_scope(self, node):
     node_stack = [node]
     node = node.parent
     while node is not None:
-      if type(node) == FunctionNode:
+      if type(node) == ast.FunctionNode:
         return node.scope
-      elif type(node) == IfNode:
+      elif type(node) == ast.IfNode:
         # elements of the test clause need to reference the next scope
         # "up" - usually the function, but could be another conditional block
         # fixme: if we ever implement "elif" this will have to get fixed up
         if node_stack[-1] != node.test_expression:
           return node.scope
-      elif type(node) == ElseNode:
+      elif type(node) == ast.ElseNode:
         return node.scope
-      elif type(node) == ForNode:
+      elif type(node) == ast.ForNode:
         if node_stack[-1] != node.expression_list:
           return node.scope
       node_stack.append(node)
       node = node.parent
-    self.compiler.error(SemanticAnalyzerError("expected a parent function"),
+    self.compiler.error(analyzer.SemanticAnalyzerError("expected a parent function"),
                         pos=node_stack[-1].pos)
 
   def get_insert_block_and_point(self, node):
@@ -189,13 +188,13 @@ class _BaseAnalyzer(object):
     insert_marker = node
     node = node.parent
     while node is not None:
-      if isinstance(node, (FunctionNode, ForNode, IfNode, ElseNode)):
+      if isinstance(node, (ast.FunctionNode, ast.ForNode, ast.IfNode, ast.ElseNode)):
         if insert_marker in node.child_nodes:
           return node, insert_marker
 
       insert_marker = node
       node = node.parent
-    self.compiler.error(SemanticAnalyzerError("expected a parent block"),
+    self.compiler.error(analyzer.SemanticAnalyzerError("expected a parent block"),
                         pos=node.pos)
 
   def replace_in_parent_block(self, node, new_node):
@@ -220,7 +219,7 @@ class _BaseAnalyzer(object):
       for alias_node, alias in conditional_node.scope.aliased_expression_map.items():
         #print "  check alias:", alias
         #print "    alias_node:", alias_node
-        assign_alias_node = AssignNode(alias, alias_node, pos=alias_node.pos)
+        assign_alias_node = ast.AssignNode(alias, alias_node, pos=alias_node.pos)
         if alias_node in parent_block.scope.aliased_expression_map:
           if self._is_condition_invariant(alias_node, conditional_node):
             #print "  hoist:", assign_alias_node
@@ -236,7 +235,7 @@ class _BaseAnalyzer(object):
     parent_block, insertion_point = self.get_insert_block_and_point(loop_node)
     # NOTE: need to iterate over items, in case we modify something
     for alias_node, alias in loop_node.scope.aliased_expression_map.items():
-      assign_alias = AssignNode(alias, alias_node, pos=alias_node.pos)
+      assign_alias = ast.AssignNode(alias, alias_node, pos=alias_node.pos)
       if alias_node in parent_block.scope.aliased_expression_map:
         if self._is_loop_invariant(alias_node, loop_node):
           self.hoist(loop_node, parent_block, insertion_point, alias_node,
@@ -280,8 +279,8 @@ class _BaseAnalyzer(object):
 #     for x in node_dependency_set:
 #       print "  dep:", x
     # find dependencies within the loop node but outside the node we're checking
-    node_dependency_set_except_node_tree = node_dependency_set - set(flatten_tree(node))
-    dependencies_within_loop = set(flatten_tree(loop_node)).intersection(
+    node_dependency_set_except_node_tree = node_dependency_set - set(walker.flatten_tree(node))
+    dependencies_within_loop = set(walker.flatten_tree(loop_node)).intersection(
       node_dependency_set_except_node_tree)
     depends_on_loop_variants = bool(loop_node.loop_variant_set.intersection(
       node_dependency_set))
@@ -301,34 +300,34 @@ class _BaseAnalyzer(object):
     return not depends_on_loop_variants and not dependencies_within_loop
 
   def get_node_dependencies(self, node):
-    node_dependency_set = set(flatten_tree(node))
+    node_dependency_set = set(walker.flatten_tree(node))
     parent_block = _get_parent_block(node)
 
     for n in list(node_dependency_set):
       # when this is an identifier, you need to check all of the potential
       # the dependencies for that symbol, which means doing some crawling
-      if isinstance(n, IdentifierNode):
+      if isinstance(n, ast.IdentifierNode):
         identifier = n
         parent_block_to_check = parent_block
         while parent_block_to_check:
           for block_node in parent_block_to_check.child_nodes:
-            if isinstance(block_node, AssignNode):
+            if isinstance(block_node, ast.AssignNode):
               if block_node.left == identifier:
                 node_dependency_set.update(
                   self.get_node_dependencies(block_node.right))
                 parent_block_to_check = None
                 break
-            elif isinstance(block_node, IfNode):
+            elif isinstance(block_node, ast.IfNode):
               # if you encounter a conditional in your chain, you depend on any
               # dependencies of the condition itself
               # FIXME: calling get_node_dependencies(block_node.test_expression)
               # causes an infinite loop, but that is probably the correct way
               # forward to address the dependency chain
               node_dependency_set.update(
-                flatten_tree(block_node.test_expression))
+                walker.flatten_tree(block_node.test_expression))
           else:
             parent_block_to_check = _get_parent_block(parent_block_to_check)
-      #elif isinstance(n, (GetUDNNode, FilterNode)):
+      #elif isinstance(n, (ast.GetUDNNode, ast.FilterNode)):
       #  node_dependency_set.update(
       #    self.get_node_dependencies(node.expression))
     #print "get_node_dependencies", node
@@ -347,10 +346,10 @@ class OptimizationAnalyzer(_BaseAnalyzer):
     for alias in sorted(self.compiler.function_name_registry):
       fq_name, method = self.compiler.function_name_registry[alias]
       fq_name_parts = fq_name.split('.')
-      self.ast_root.from_nodes.append(FromNode(
-        [IdentifierNode(x) for x in fq_name_parts[:-1]],
-        IdentifierNode(fq_name_parts[-1]),
-        IdentifierNode(alias)))
+      self.ast_root.from_nodes.append(ast.FromNode(
+        [ast.IdentifierNode(x) for x in fq_name_parts[:-1]],
+        ast.IdentifierNode(fq_name_parts[-1]),
+        ast.IdentifierNode(alias)))
 
     for n in template.from_nodes:
       if n.alias:
@@ -360,7 +359,7 @@ class OptimizationAnalyzer(_BaseAnalyzer):
 
     # scan extends for dependencies
     # this allows faster calling of template functions - we could also
-    # tune BufferWrite calls for these nodes
+    # tune ast.BufferWrite calls for these nodes
     if self.options.use_dependency_analysis:
       for n in template.extends_nodes:
         path = os.path.join(
@@ -374,7 +373,7 @@ class OptimizationAnalyzer(_BaseAnalyzer):
       self.visit_ast(n, template)
 
   def analyzeFunctionNode(self, function):
-    function.scope.local_identifiers.update([IdentifierNode(n.name)
+    function.scope.local_identifiers.update([ast.IdentifierNode(n.name)
                                           for n in function.parameter_list])
     # Some binops optimzations can only be done in functions.
     self.binop_count = _BINOP_INITIAL_COUNT
@@ -393,21 +392,21 @@ class OptimizationAnalyzer(_BaseAnalyzer):
     scope = self.get_parent_scope(node)
     local_identifiers, _, dirty_identifiers = _get_local_identifiers(node)
     # This is an assignment at an index.
-    if isinstance(node.left, SliceNode):
-      _identifier = IdentifierNode(node.left.expression.name, pos=node.pos)
+    if isinstance(node.left, ast.SliceNode):
+      _identifier = ast.IdentifierNode(node.left.expression.name, pos=node.pos)
       scope.dirty_local_identifiers.add(_identifier)
       if _identifier not in local_identifiers:
         self.compiler.error(
-            SemanticAnalyzerError(
+            analyzer.SemanticAnalyzerError(
                 'Expression %s being indexed must be defined before use' %
                 _identifier.name), pos=node.pos)
     else:
-      _identifier = IdentifierNode(node.left.name, pos=node.pos)
+      _identifier = ast.IdentifierNode(node.left.name, pos=node.pos)
       alias_name = _generate_filtered_placeholder(_identifier)
       if alias_name in scope.alias_name_set:
         if self.options.double_assign_error:
           self.compiler.error(
-              SemanticAnalyzerError('Multiple assignment of %s' %
+              analyzer.SemanticAnalyzerError('Multiple assignment of %s' %
                                     _identifier.name), pos=node.pos)
         else:
           self.compiler.warn('Multiple assignment of %s' % _identifier.name,
@@ -426,7 +425,7 @@ class OptimizationAnalyzer(_BaseAnalyzer):
     flat_list = []
     for n in target_list_node:
       self.visit_ast(n, target_list_node)
-      if type(n) == TargetListNode:
+      if type(n) == ast.TargetListNode:
         flat_list.extend(n.flat_list)
       else:
         flat_list.append(n)
@@ -446,11 +445,11 @@ class OptimizationAnalyzer(_BaseAnalyzer):
       # we don't consider the final call a modification. This assumption is
       # predictaed on the fact that you can't modify a variable once it has been
       # written.
-      if not _get_parent_node_by_type(arg_list_node, FilterNode):
-        if isinstance(n, PlaceholderNode):
-          scope.dirty_local_identifiers.add(IdentifierNode(n.name))
-        if isinstance(n, ParameterNode) and isinstance(n.default, PlaceholderNode):
-          scope.dirty_local_identifiers.add(IdentifierNode(n.default.name))
+      if not _get_parent_node_by_type(arg_list_node, ast.FilterNode):
+        if isinstance(n, ast.PlaceholderNode):
+          scope.dirty_local_identifiers.add(ast.IdentifierNode(n.name))
+        if isinstance(n, ast.ParameterNode) and isinstance(n.default, ast.PlaceholderNode):
+          scope.dirty_local_identifiers.add(ast.IdentifierNode(n.default.name))
       self.visit_ast(n, arg_list_node)
 
   def analyzeTupleLiteralNode(self, tuple_literal_node):
@@ -470,24 +469,24 @@ class OptimizationAnalyzer(_BaseAnalyzer):
     self.visit_ast(do_node.expression, do_node)
 
   def analyzeCallFunctionNode(self, function_call):
-    # If the CallFunctionNode is in the test expression of an IfNode, do not
+    # If the ast.CallFunctionNode is in the test expression of an ast.IfNode, do not
     # wrap the function with a SanitizedPlaceholder.
     def is_in_test_expression(node):
-      return (isinstance(node.parent, IfNode) and
+      return (isinstance(node.parent, ast.IfNode) and
               node == node.parent.test_expression)
     if _get_parent_node_by_pred(function_call, is_in_test_expression,
                                 search_current=True):
-      function_call.sanitization_state = SanitizedState.NOT_OUTPUTTED
-    # If the CallFunctionNode is in a DoNode, do not wrap the function with a
+      function_call.sanitization_state = ast.SanitizedState.NOT_OUTPUTTED
+    # If the ast.CallFunctionNode is in a ast.DoNode, do not wrap the function with a
     # SanitizedPlaceholder.
-    if _get_parent_node_by_type(function_call, DoNode):
-      function_call.sanitization_state = SanitizedState.NOT_OUTPUTTED
+    if _get_parent_node_by_type(function_call, ast.DoNode):
+      function_call.sanitization_state = ast.SanitizedState.NOT_OUTPUTTED
 
     self.visit_ast(function_call.expression, function_call)
     self.visit_ast(function_call.arg_list, function_call)
 
   # NOTE: these optimizations are disabled because the optimizer has a tendency
-  # to "over-hoist" code inside a CacheNode and you end up doing *more* work
+  # to "over-hoist" code inside a ast.CacheNode and you end up doing *more* work
   def analyzeCacheNode(self, cache_node):
     cache_placeholders = self.options.cache_resolved_placeholders
     cache_udn_expressions = self.options.cache_resolved_udn_expressions
@@ -505,11 +504,11 @@ class OptimizationAnalyzer(_BaseAnalyzer):
   def analyzeBufferWrite(self, buffer_write):
     self.visit_ast(buffer_write.expression, buffer_write)
     # template functions output text - don't format them as strings
-    if (isinstance(buffer_write.expression, BinOpNode) and
+    if (isinstance(buffer_write.expression, ast.BinOpNode) and
         buffer_write.expression.operator == '%' and
-        isinstance(buffer_write.expression.right, CallFunctionNode) and
+        isinstance(buffer_write.expression.right, ast.CallFunctionNode) and
         isinstance(buffer_write.expression.right.expression,
-                   TemplateMethodIdentifierNode)):
+                   ast.TemplateMethodIdentifierNode)):
       buffer_write.replace(
         buffer_write.expression, buffer_write.expression.right)
 
@@ -521,41 +520,41 @@ class OptimizationAnalyzer(_BaseAnalyzer):
   def analyzeFilterNode(self, filter_node):
     self.visit_ast(filter_node.expression, filter_node)
 
-    if isinstance(filter_node.expression, CallFunctionNode):
-      # If a FilterNode has a CallFunctionNode as an expression, let the filter
+    if isinstance(filter_node.expression, ast.CallFunctionNode):
+      # If a ast.FilterNode has a ast.CallFunctionNode as an expression, let the filter
       # node handle determining if filtering should occur, rather than the
       # sanitization wrapper.
       filter_node.expression.sanitization_state = (
-          SanitizedState.OUTPUTTED_IMMEDIATELY)
+          ast.SanitizedState.OUTPUTTED_IMMEDIATELY)
 
-    if (isinstance(filter_node.expression, CallFunctionNode) and
-        isinstance(filter_node.expression.expression, TemplateMethodIdentifierNode)):
+    if (isinstance(filter_node.expression, ast.CallFunctionNode) and
+        isinstance(filter_node.expression.expression, ast.TemplateMethodIdentifierNode)):
       filter_node.parent.replace(filter_node, filter_node.expression)
       return
 
-    # A CallFunctionNode will require passing in both the value and the
-    # function to the filter_function. If the CallFunctionNode's expression is a
-    # GetUDNNode, we can avoid looking up the attribute twice by caching its
-    # value. This is also true if the CallFunctionNode's expression is an
-    # IdentifierNode with a '.' in the name.
-    if isinstance(filter_node.expression, CallFunctionNode):
+    # A ast.CallFunctionNode will require passing in both the value and the
+    # function to the filter_function. If the ast.CallFunctionNode's expression is a
+    # ast.GetUDNNode, we can avoid looking up the attribute twice by caching its
+    # value. This is also true if the ast.CallFunctionNode's expression is an
+    # ast.IdentifierNode with a '.' in the name.
+    if isinstance(filter_node.expression, ast.CallFunctionNode):
       fn_node = filter_node.expression
       if (self.options.cache_resolved_udn_expressions and
-          isinstance(fn_node.expression, IdentifierNode) and
+          isinstance(fn_node.expression, ast.IdentifierNode) and
           '.' in fn_node.expression.name):
         scope = self.get_parent_scope(filter_node)
         udn_node = fn_node.expression
         # For some udn style node, create a cached variable. ex. _rudn12345
         alias_name = _generate_cached_resolved_placeholder(udn_node)
-        alias = IdentifierNode(alias_name, pos=filter_node.pos)
+        alias = ast.IdentifierNode(alias_name, pos=filter_node.pos)
         scope.local_identifiers.add(alias)
         # Create an assignment node that assigns the udn node to the
-        # IdentifierNode.
-        assign_alias = AssignNode(alias, udn_node, pos=filter_node.pos)
+        # ast.IdentifierNode.
+        assign_alias = ast.AssignNode(alias, udn_node, pos=filter_node.pos)
         insert_block, insert_marker = self.get_insert_block_and_point(filter_node)
-        # Insert the assignment before the FilterNode
+        # Insert the assignment before the ast.FilterNode
         insert_block.insert_before(insert_marker, assign_alias)
-        # Replace the udn node in the CallFunctionNode with the alias.
+        # Replace the udn node in the ast.CallFunctionNode with the alias.
         filter_node.expression.replace(udn_node, alias)
 
     if self.options.cache_filtered_placeholders:
@@ -574,10 +573,10 @@ class OptimizationAnalyzer(_BaseAnalyzer):
           print "scope.aliased_expression_map", scope.aliased_expression_map
           return
 
-        alias = IdentifierNode(alias_name, pos=filter_node.pos)
+        alias = ast.IdentifierNode(alias_name, pos=filter_node.pos)
         scope.alias_name_set.add(alias_name)
         scope.aliased_expression_map[filter_node] = alias
-        assign_alias = AssignNode(alias, filter_node, pos=filter_node.pos)
+        assign_alias = ast.AssignNode(alias, filter_node, pos=filter_node.pos)
 
         insert_block, insert_marker = self.get_insert_block_and_point(
           filter_node)
@@ -588,15 +587,15 @@ class OptimizationAnalyzer(_BaseAnalyzer):
 
   def _placeholdernode_replacement(self, placeholder, local_var,
                                    cached_placeholder, local_identifiers):
-    """This function tries to replace a PlaceholderNode with a node type
-    that does not need to be resolved such as an IdentifierNode or a
+    """This function tries to replace a ast.PlaceholderNode with a node type
+    that does not need to be resolved such as an ast.IdentifierNode or a
     cached placeholder.
     """
     if local_var in local_identifiers:
       placeholder.parent.replace(placeholder, local_var)
     elif placeholder.name in self.ast_root.template_methods:
       placeholder.parent.replace(
-          placeholder, TemplateMethodIdentifierNode(
+          placeholder, ast.TemplateMethodIdentifierNode(
               placeholder.name))
     elif local_var in self.ast_root.global_identifiers:
       placeholder.parent.replace(placeholder, local_var)
@@ -604,7 +603,7 @@ class OptimizationAnalyzer(_BaseAnalyzer):
       placeholder.parent.replace(placeholder, cached_placeholder)
     elif local_var.name in builtin_names:
       placeholder.parent.replace(placeholder,
-                                 IdentifierNode(local_var.name))
+                                 ast.IdentifierNode(local_var.name))
     elif self.options.cache_resolved_placeholders:
       scope = self.get_parent_scope(placeholder)
       scope.alias_name_set.add(cached_placeholder.name)
@@ -619,7 +618,7 @@ class OptimizationAnalyzer(_BaseAnalyzer):
       # analyze a certain set of nodes. you only really need to analyze
       # that the assignment took place, then you can safely alias the
       # actual function call. definitely sketchy, but it does seem to work
-      assign_rph = AssignNode(cached_placeholder, None, pos=placeholder.pos)
+      assign_rph = ast.AssignNode(cached_placeholder, None, pos=placeholder.pos)
       cached_placeholder.parent = assign_rph
       #print "optimize scope:", insert_block
       #print "optimize marker:", insert_marker
@@ -632,19 +631,19 @@ class OptimizationAnalyzer(_BaseAnalyzer):
 
   def analyzePlaceholderNode(self, placeholder):
     if self.options.directly_access_defined_variables:
-      # when the analyzer finds a PlaceholderNode and generates a function
-      # call out of it, i annotate an IdentifierNode with the original
+      # when the analyzer finds a ast.PlaceholderNode and generates a function
+      # call out of it, i annotate an ast.IdentifierNode with the original
       # placeholder name
-      local_var = IdentifierNode(placeholder.name, pos=placeholder.pos)
-      cached_placeholder = IdentifierNode('_rph_%s' % local_var.name,
+      local_var = ast.IdentifierNode(placeholder.name, pos=placeholder.pos)
+      cached_placeholder = ast.IdentifierNode('_rph_%s' % local_var.name,
                                           pos=placeholder.pos)
       (local_identifiers, partial_local_identifiers, _) = (
           _get_local_identifiers(placeholder))
-      attrs = set([IdentifierNode(node.name) for node in self.ast_root.attr_nodes])
+      attrs = set([ast.IdentifierNode(node.name) for node in self.ast_root.attr_nodes])
       non_local_identifiers = (partial_local_identifiers -
                                local_identifiers - attrs)
       if (self.options.static_analysis and local_var in non_local_identifiers):
-        self.compiler.error(SemanticAnalyzerError(
+        self.compiler.error(analyzer.SemanticAnalyzerError(
             ('Variable %s is not guaranteed to be in scope. '
             'Define the variable in all branches of the conditional '
             'or before the conditional.') % local_var), pos=placeholder.pos)
@@ -667,9 +666,9 @@ class OptimizationAnalyzer(_BaseAnalyzer):
 #         print "duplicate alias_name", alias_name
 #         return
 
-#       alias = IdentifierNode(alias_name)
+#       alias = ast.IdentifierNode(alias_name)
 #       function.aliased_expression_map[expression] = alias
-#       assign_alias = AssignNode(alias, expression)
+#       assign_alias = ast.AssignNode(alias, expression)
 #       parent_loop = _get_parent_loop(node)
 #       # fixme: check to see if this expression is loop-invariant
 #       # must add a test case for this
@@ -693,7 +692,7 @@ class OptimizationAnalyzer(_BaseAnalyzer):
 
     # fixme: only handle the trivial case for now
     # simplifies the protocol for making up alias names
-    if type(node.expression) != IdentifierNode:
+    if type(node.expression) != ast.IdentifierNode:
       return
 
     scope = self.get_parent_scope(node)
@@ -712,10 +711,10 @@ class OptimizationAnalyzer(_BaseAnalyzer):
         print "scope.aliased_expression_map", scope.aliased_expression_map
         return
 
-      alias = IdentifierNode(alias_name)
+      alias = ast.IdentifierNode(alias_name)
       scope.alias_name_set.add(alias_name)
       scope.aliased_expression_map[node] = alias
-      assign_alias = AssignNode(alias, node)
+      assign_alias = ast.AssignNode(alias, node)
 
       parent_loop = _get_parent_loop(node)
       # fixme: check to see if this expression is loop-invariant
@@ -801,7 +800,7 @@ class OptimizationAnalyzer(_BaseAnalyzer):
   def analyzeBinOpNode(self, n):
     # if you are trying to use short-circuit behavior, these two optimizations
     # can sabotage correct execution since the rhs may be hoisted above the
-    # IfNode and cause it to get executed prior to passing the lhs check.
+    # ast.IfNode and cause it to get executed prior to passing the lhs check.
     should_visit_left = True
     and_or_operator = n.operator in ('and', 'or')
     if and_or_operator:
@@ -835,19 +834,19 @@ class OptimizationAnalyzer(_BaseAnalyzer):
       self.visit_ast(node.expression, node)
 
     # If self._filter_function is created in a macro, make sure we rename it.
-    self_node = IdentifierNode('self')
+    self_node = ast.IdentifierNode('self')
     if node.expression == self_node and node.name == '_filter_function':
-      alias = IdentifierNode('_self_private_filter_function', pos=node.pos)
+      alias = ast.IdentifierNode('_self_private_filter_function', pos=node.pos)
       node.parent.replace(node, alias)
       return
     # If self.filter_function is created in a macro, make sure we rename it.
     if node.expression == self_node and node.name == 'filter_function':
-      alias = IdentifierNode('_self_filter_function', pos=node.pos)
+      alias = ast.IdentifierNode('_self_filter_function', pos=node.pos)
       node.parent.replace(node, alias)
       return
 
     if self.options.cache_resolved_udn_expressions:
-      cached_udn = IdentifierNode(_generate_cached_resolved_placeholder(node),
+      cached_udn = ast.IdentifierNode(_generate_cached_resolved_placeholder(node),
                                   pos=node.pos)
       (local_identifiers, _, _) = _get_local_identifiers(node)
       if cached_udn in local_identifiers:
@@ -864,7 +863,7 @@ class OptimizationAnalyzer(_BaseAnalyzer):
         # you have a problem - you won't ever use the new string create by
         # the first call to replace
         for child_node in insert_block.child_nodes:
-          if (isinstance(child_node, AssignNode) and
+          if (isinstance(child_node, ast.AssignNode) and
               child_node.left == node.expression):
             return
 
@@ -880,7 +879,7 @@ class OptimizationAnalyzer(_BaseAnalyzer):
         # analyze a certain set of nodes. you only really need to analyze
         # that the assignment took place, then you can safely alias the
         # actual function call. definitely sketchy, but it does seem to work
-        assign_rph = AssignNode(cached_udn, None, pos=node.pos)
+        assign_rph = ast.AssignNode(cached_udn, None, pos=node.pos)
         cached_udn.parent = assign_rph
         insert_block.insert_before(
           insert_marker, assign_rph)
@@ -933,17 +932,17 @@ class FinalPassAnalyzer(_BaseAnalyzer):
       self.collect_writes(if_node.else_)
 
   def analyzeBufferWrite(self, buffer_write):
-    """Perform BufferWrite optimizations.
+    """Perform ast.BufferWrite optimizations.
 
     Do this in the final pass optimizer to make sure that the
     optimization is handled after caching placeholders.
     """
     self.visit_ast(buffer_write.expression, buffer_write)
     # All filterning is done before writing to the buffer. If the function
-    # output needed filtering then it would be wrapped in a FilterNode.
-    if isinstance(buffer_write.expression, CallFunctionNode):
+    # output needed filtering then it would be wrapped in a ast.FilterNode.
+    if isinstance(buffer_write.expression, ast.CallFunctionNode):
       buffer_write.expression.sanitization_state = (
-          SanitizedState.OUTPUTTED_IMMEDIATELY)
+          ast.SanitizedState.OUTPUTTED_IMMEDIATELY)
 
   def hoist(self, parent_node, parent_block, insertion_point, alias_node,
             assign_alias_node):
@@ -960,16 +959,16 @@ class FinalPassAnalyzer(_BaseAnalyzer):
       # when a variable aliased in both the if and
       # else blocks is promoted to the parent scope
       # the implementation isn't actually hoisted (should it be?)
-      # inline with the IfNode optimization so we need to check if the
+      # inline with the ast.IfNode optimization so we need to check if the
       # node is already here
       if assign_alias_node in parent_block.child_nodes:
         current_pos = parent_block.child_nodes.index(assign_alias_node)
-        # an else node's parent is the IfNode, which is the relevant
+        # an else node's parent is the ast.IfNode, which is the relevant
         # node when searching for the insertion point
         needed_pos = parent_block.child_nodes.index(insertion_point)
         if needed_pos < current_pos:
           parent_block.child_nodes.remove(assign_alias_node)
-          if isinstance(parent_node, ElseNode):
+          if isinstance(parent_node, ast.ElseNode):
             parent_block.insert_before(parent_node.parent, assign_alias_node)
           else:
             parent_block.insert_before(parent_node, assign_alias_node)
@@ -985,23 +984,23 @@ class FinalPassAnalyzer(_BaseAnalyzer):
     parent_node.scope.alias_name_set.remove(assign_alias_node.left.name)
     # FIXME: this is probably an indication of a bug or unnecessary
     # difference between the caching of placeholders and filter expressions
-    if not isinstance(alias_node, FilterNode):
+    if not isinstance(alias_node, ast.FilterNode):
       parent_node.scope.local_identifiers.remove(assign_alias_node.left)
 
   def make_write_node(self, write_list):
-    """Convert a list of expressions to be written into a single ASTNode.
-    This will return either be a BufferWrite node, a BufferExtend node or
+    """Convert a list of expressions to be written into a single ast.ASTNode.
+    This will return either be a ast.BufferWrite node, a ast.BufferExtend node or
     None if write_list is empty."""
     if not write_list:
       return None
     # If there is only a single node, avoid the overhead of
     # constructing a tuple.
     if len(write_list) == 1:
-      return BufferWrite(write_list[0])
-    tuple_node = TupleLiteralNode()
+      return ast.BufferWrite(write_list[0])
+    tuple_node = ast.TupleLiteralNode()
     for exp in write_list:
       tuple_node.append(exp)
-    return BufferExtend(tuple_node)
+    return ast.BufferExtend(tuple_node)
 
   def collect_writes(self, node):
     """Look at all the writes that are children of the node and move them to
@@ -1010,20 +1009,20 @@ class FinalPassAnalyzer(_BaseAnalyzer):
     are all together, they can be batched into a buffer.extend operation. This
     avoids list resize operations."""
 
-    passable_nodes = (AssignNode, CacheNode)
+    passable_nodes = (ast.AssignNode, ast.CacheNode)
 
-    # ASTNode.insert_before is broken in a way that if there are
+    # ast.ASTNode.insert_before is broken in a way that if there are
     # duplicate nodes, inserts always occur before the first one. To
-    # deal with this, we construct a new NodeList rather than
+    # deal with this, we construct a new ast.NodeList rather than
     # modifying the original one.
     old_node_list = node.child_nodes
-    node.child_nodes = NodeList()
+    node.child_nodes = ast.NodeList()
 
     write_list = []
     for n in old_node_list:
-      if isinstance(n, BufferWrite):
+      if isinstance(n, ast.BufferWrite):
         write_list.append(n.expression)
-      elif isinstance(n, BufferExtend):
+      elif isinstance(n, ast.BufferExtend):
         write_list.extend(n.expression.child_nodes)
       elif not isinstance(n, passable_nodes):
         write_node = self.make_write_node(write_list)

--- a/spitfire/compiler/parser_test.py
+++ b/spitfire/compiler/parser_test.py
@@ -6,7 +6,7 @@
 import logging
 import unittest
 
-from spitfire.compiler.ast import *
+from spitfire.compiler import ast
 from spitfire.compiler import util
 from spitfire.compiler import walker
 from third_party.yapps2 import yappsrt
@@ -24,7 +24,7 @@ class TestEscapeHash(BaseTest):
 
   @staticmethod
   def _def_foo_pred(node):
-      return type(node) == DefNode and node.name == 'foo'
+      return type(node) == ast.DefNode and node.name == 'foo'
 
   def test_escape_simple(self):
     code = """
@@ -35,7 +35,7 @@ class TestEscapeHash(BaseTest):
     template = self._compile(code)
 
     def_node = walker.find_node(template, TestEscapeHash._def_foo_pred)
-    text = ''.join([node.value for node in def_node.child_nodes if type(node) == TextNode])
+    text = ''.join([node.value for node in def_node.child_nodes if type(node) == ast.TextNode])
     self.assertEqual(text, '#test')
 
 
@@ -48,7 +48,7 @@ class TestEscapeHash(BaseTest):
     template = self._compile(code)
 
     def_node = walker.find_node(template, TestEscapeHash._def_foo_pred)
-    text = ''.join([node.value for node in def_node.child_nodes if type(node) == TextNode])
+    text = ''.join([node.value for node in def_node.child_nodes if type(node) == ast.TextNode])
     self.assertEqual(text, '\\#test')
 
   def test_escape_needed(self):
@@ -60,7 +60,7 @@ class TestEscapeHash(BaseTest):
     template = self._compile(code)
 
     def_node = walker.find_node(template, TestEscapeHash._def_foo_pred)
-    text = ''.join([node.value for node in def_node.child_nodes if type(node) == TextNode])
+    text = ''.join([node.value for node in def_node.child_nodes if type(node) == ast.TextNode])
     self.assertEqual(text, '#if')
 
 
@@ -68,7 +68,7 @@ class TestDo(BaseTest):
 
   @staticmethod
   def _do_pred(node):
-    return type(node) == DoNode
+    return type(node) == ast.DoNode
 
   def test_do_syntax(self):
     code = """
@@ -109,7 +109,7 @@ class TestAllowRaw(BaseTest):
 
   @staticmethod
   def _allow_raw_pred(node):
-    return type(node) == AllowRawNode
+    return type(node) == ast.AllowRawNode
 
   def test_allow_raw(self):
     code = """
@@ -122,7 +122,7 @@ class TestAllowRaw(BaseTest):
 
     allow_raw_node = walker.find_node(template, TestAllowRaw._allow_raw_pred)
     if not allow_raw_node:
-      self.fail('AllowRawNode should be present in AST')
+      self.fail('ast.AllowRawNode should be present in AST')
 
 
 if __name__ == '__main__':

--- a/spitfire/compiler/scanner.py
+++ b/spitfire/compiler/scanner.py
@@ -3,9 +3,8 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+from spitfire.compiler import parser
 from third_party.yapps2 import yappsrt
-
-import spitfire.compiler.parser
 
 # SpitfireScanner uses the order of the match, not the length of the match to
 # determine what token to return. I'm not sure how fragille this is long-term,
@@ -14,7 +13,7 @@ import spitfire.compiler.parser
 _restrict_cache = {}
 
 
-class SpitfireScanner(spitfire.compiler.parser._SpitfireParserScanner):
+class SpitfireScanner(parser._SpitfireParserScanner):
   def token(self, i, restrict=0):
     """Get the i'th token, and if i is one past the end, then scan
     for another token; restrict is a list of tokens that

--- a/spitfire/runtime/filters.py
+++ b/spitfire/runtime/filters.py
@@ -5,7 +5,8 @@
 
 # a few helpful filter functions
 
-from spitfire.runtime.udn import UndefinedPlaceholder
+from spitfire import runtime
+from spitfire.runtime import udn
 
 # decorate a function object so the default filter will not be applied to the
 # value of a placeholder. this is handy when building functions that will
@@ -33,14 +34,14 @@ def escape_html(value, quote=True):
 # deprecated
 def safe_values(value):
   """Deprecated - use simple_str_filter instead."""
-  if isinstance(value, (str, unicode, int, long, float, UndefinedPlaceholder)):
+  if isinstance(value, (str, unicode, int, long, float, runtime.UndefinedPlaceholder)):
     return value
   else:
     return ''
 
 def simple_str_filter(value):
   """Return a string if the input type is something primitive."""
-  if isinstance(value, (str, unicode, int, long, float, UndefinedPlaceholder)):
+  if isinstance(value, (str, unicode, int, long, float, runtime.UndefinedPlaceholder)):
     # fixme: why do force this conversion here?
     # do we want to be unicode or str?
     return str(value)

--- a/spitfire/runtime/runner.py
+++ b/spitfire/runtime/runner.py
@@ -4,28 +4,27 @@
 # license that can be found in the LICENSE file.
 
 import logging
+import optparse
 import os.path
 import sys
 
 import cPickle as pickle
 
-from optparse import OptionParser
-
 
 def run_template(class_object):
-  parser = OptionParser()
-  parser.add_option('-f', dest='filename',
+  option_parser = optparse.OptionParser()
+  option_parser.add_option('-f', dest='filename',
                     help='data file for template search list')
-  (options, args) = parser.parse_args()
+  (tmpl_options, tmpl_args) = option_parser.parse_args()
 
-  if options.filename:
-    data = [load_search_list(options.filename)]
+  if tmpl_options.filename:
+    data = [load_search_list(tmpl_options.filename)]
   else:
     data = []
   template = class_object(search_list=data)
   sys.stdout.write(template.main())
-  
-  
+
+
 def load_search_list(filename):
   f = open(filename)
   raw_data = f.read()

--- a/spitfire/runtime/template.py
+++ b/spitfire/runtime/template.py
@@ -5,15 +5,13 @@
 
 # an 'abstract' base class for a template, seems like a good idea for now
 
-#import StringIO
 import cStringIO as StringIO
-from spitfire.runtime import baked
-import spitfire.runtime.filters
-import spitfire.runtime.repeater
-from spitfire.runtime import _template
 
-from spitfire.runtime.udn import (
-  _resolve_from_search_list, UnresolvedPlaceholder)
+from spitfire import runtime
+from spitfire.runtime import _template
+from spitfire.runtime import baked
+from spitfire.runtime import filters
+from spitfire.runtime import udn
 
 # NOTE: in some instances, this is faster than using cStringIO
 # this is slightly counter intuitive and probably means there is more here than
@@ -33,7 +31,7 @@ class SpitfireTemplate(_template.BaseSpitfiretemplate):
   # when this is assigned to a template instance, accessing this name binds the
   # function to the current instance. using the name 'template_instance' to
   # indicate that these functions aren't really related to the template.
-  _filter_function = staticmethod(spitfire.runtime.filters.simple_str_filter)
+  _filter_function = staticmethod(filters.simple_str_filter)
   repeat = None
   placeholder_cache = None
 
@@ -52,11 +50,11 @@ class SpitfireTemplate(_template.BaseSpitfiretemplate):
     # self.repeat = spitfire.runtime.repeater.RepeatTracker()
 
   def get_var(self, name, default=None):
-    return _resolve_from_search_list(self.search_list, name, default)
+    return udn._resolve_from_search_list(self.search_list, name, default)
 
   def has_var(self, name):
-    var = self.get_var(name, default=UnresolvedPlaceholder)
-    return var is not UnresolvedPlaceholder
+    var = self.get_var(name, default=runtime.UnresolvedPlaceholder)
+    return var is not runtime.UnresolvedPlaceholder
 
   # wrap the underlying filter call so that items don't get filtered multiple
   # times (avoids double escaping)

--- a/spitfire/runtime/udn_test.py
+++ b/spitfire/runtime/udn_test.py
@@ -5,6 +5,7 @@
 
 import unittest
 
+from spitfire import runtime
 from spitfire.runtime import _udn
 from spitfire.runtime import udn
 
@@ -17,7 +18,7 @@ class Foo(object):
   bar = 'baz'
   search_list = [
     {'win': 'boo'},
-    Scope(),
+   Scope(),
   ]
   placeholder_cache = None
 
@@ -41,7 +42,7 @@ class TestResolvePlaceholder(unittest.TestCase):
 
   def test_undefined(self):
     self.assertEqual(type(udn.resolve_placeholder('wowza', Foo, None)),
-                     udn.UndefinedPlaceholder)
+                     runtime.UndefinedPlaceholder)
 
 
 class TestResolvePlaceholderWithCache(unittest.TestCase):
@@ -86,17 +87,17 @@ class _UdnTest(object):
 
   def testResolveMissWithoutException(self):
     self.assertIsInstance(self.resolve_udn(Baz(), 'missing'),
-                          udn.UndefinedAttribute)
+                          runtime.UndefinedAttribute)
 
   def testResolveDoubleMissWithoutException(self):
     """Shows that it's UndefinedAttribute's all the way down."""
     undefined_attr = self.resolve_udn(Baz(), 'missing')
-    self.assertIsInstance(undefined_attr, udn.UndefinedAttribute)
+    self.assertIsInstance(undefined_attr, runtime.UndefinedAttribute)
     undefined_attr2 = self.resolve_udn(undefined_attr, 'missing')
-    self.assertIsInstance(undefined_attr2, udn.UndefinedAttribute)
+    self.assertIsInstance(undefined_attr2, runtime.UndefinedAttribute)
 
   def testResolveMissWithException(self):
-    self.assertRaises(udn.UDNResolveError, self.resolve_udn, Baz(), 'misssing',
+    self.assertRaises(runtime.UDNResolveError, self.resolve_udn, Baz(), 'misssing',
                       raise_exception=True)
 
 


### PR DESCRIPTION
This change standardizes all imports to the `from PACKAGE import MODULE` form.
This means that
```py
import spitfire.compiler.parser
...
spitfire.compiler.parser.SpitfireParser(...)
```
becomes
```py
from spitfire.compiler import parser
...
parser.SpitfireParser(...)
```

Also, all `from PACKAGE.MODULE import *` forms have been removed, and the
relevant references prefixed with the module name.  This means that
```py
from spitfire.compiler.ast import *
...
FunctionNode(...)
```
becomes
```py
from spitfire.compiler import ast
...
ast.FunctionNode(...)
```

Finally, all module aliasing has been removed except for those cases where
a C-based module is used in favor of a Python-based one.  This means that
```py
import cStringIO as StringIO
import spitfire.compiler.compiler as sptcompiler
...
compiler = sptcompiler.Compiler(...)
```
becomes
```py
import cStringIO as StringIO
from spitfire.compiler import compiler
...
spt_compiler = compiler.Compiler(...)
```

Closes #27