### PR TITLE
Provide a default value for the "include_sourcemap" option.

### DIFF
--- a/spitfire/compiler/options.py
+++ b/spitfire/compiler/options.py
@@ -114,6 +114,9 @@ class AnalyzerOptions(object):
     # Disallow the use of raw in a template.
     self.no_raw = False
 
+    # Generate line number comments in compiler output.
+    self.include_sourcemap = False
+
     self.__dict__.update(kargs)
 
   def update(self, **kargs):


### PR DESCRIPTION
This fixes an exception when `compiler.compile_template` is called directly
with a template string.